### PR TITLE
Remove Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -149,16 +149,6 @@ jekyll-theme-WuK: # 我的主题的自定义样式都在这个命名空间
           src='https://zz.bdstatic.com/linksubmit/push.js'
           async="async"
         ></script>
-      - | #<!-- Global site tag (gtag.js) - Google Analytics -->
-        <script
-          async="async"
-          src="https://www.googletagmanager.com/gtag/js?id=UA-163543967-1"
-          onload="
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'UA-163543967-1');"
-        ></script>
       - | # 网站背景图片，分竖屏、宽屏；改链接即可，不想用可以把这一项全删掉；要换壁纸图片的话可把url内的部分换成你自己的，比如你放在 /assets/image/background.jpg，那就改成 url(/assets/image/background.jpg)
         <style>
           .wrap {


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/